### PR TITLE
[Feature] Relay Fee to protect spamming attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Shuttle is a Terra-Ethereum bridge. Currently only allows Terra assets to be sen
   - [Terra Denoms and Contracts](#terra-denoms-and-contracts)
   - [Usage Instructions](#usage-instructions)
     - [Terra => Ethereum / BSC](#terra--ethereum--bsc)
+      - [Native Assets](#native-assets)
+      - [CW20 Tokens](#cw20-tokens)
     - [Ethereum / BSC => Terra](#ethereum--bsc--terra)
+  - [Relaying Fee](#relaying-fee)
 
 ## Components
 
@@ -226,3 +229,7 @@ Ex)
 - Terra Tx:
 
   https://finder.terra.money/tequila-0004/tx/AE2325AC4B5193ABD0CEB8A6708070A0D5C481264755313E23B854FF8005EFAC
+
+
+## Relaying Fee
+Shuttle charges a fee only for transferring assets from Terra to Ethereum, and the quantity is calculated as `max($1, 0.1% * amount)`. **A transaction with tiny amount smaller than $1 value will be ignored.**

--- a/terra/.env_example
+++ b/terra/.env_example
@@ -11,6 +11,12 @@ ETH_DONATION="0xad01D44ec74C79DC982fB0AbEfc8304fD2e18153"
 ETH_MNEMONIC="forget cluster father know insect gospel firm spring anxiety capable struggle absent apart menu stand grass unknown deal cover key enough bottom mean outside"
 
 FEE_RATE="0.001"
+FEE_MIN_AMOUNT="1000000"
+FEE_QUOTE_TICKER="USD"
+
+FIXER_API_KEY=""
+POLYGON_API_KEY=""
+
 REDIS_URL="redis://127.0.0.1:6379"
 
 SLACK_NOTI_NETWORK="TESTNET"

--- a/terra/src/Monitoring.ts
+++ b/terra/src/Monitoring.ts
@@ -95,7 +95,9 @@ export class Monitoring {
         limit,
       });
 
-      monitoringDatas.push(...txResult.txs.map(this.parseTx.bind(this)).flat());
+      monitoringDatas.push(
+        ...(await Promise.all(txResult.txs.map(this.parseTx.bind(this)))).flat()
+      );
 
       totalPage = txResult.page_total;
     } while (page++ < totalPage);
@@ -137,7 +139,7 @@ export class Monitoring {
 
             // Compute minimum fee with oracle price
             const price = await this.oracle.getPrice(asset);
-            const minFee = FEE_MIN_AMOUNT.dividedBy(price)
+            const minFee = FEE_MIN_AMOUNT.dividedBy(price);
 
             // Skip logging or other actions for tiny amount transaction
             if (requested < minFee) {

--- a/terra/src/Monitoring.ts
+++ b/terra/src/Monitoring.ts
@@ -142,7 +142,7 @@ export class Monitoring {
             const minFee = FEE_MIN_AMOUNT.dividedBy(price);
 
             // Skip logging or other actions for tiny amount transaction
-            if (requested < minFee) {
+            if (requested.lte(minFee)) {
               continue;
             }
 

--- a/terra/src/Monitoring.ts
+++ b/terra/src/Monitoring.ts
@@ -8,7 +8,7 @@ import {
 import EthContractInfos from './config/EthContractInfos';
 import TerraAssetInfos from './config/TerraAssetInfos';
 import BigNumber from 'bignumber.js';
-import Oracle from 'Oracle';
+import Oracle from './Oracle';
 
 BigNumber.config({ ROUNDING_MODE: BigNumber.ROUND_DOWN });
 

--- a/terra/src/Oracle.ts
+++ b/terra/src/Oracle.ts
@@ -82,10 +82,10 @@ class Oracle {
 
     if (type === 'forex') {
       const rates = response['rates'];
-      const priceBase = rates[QUOTE_TICKER]; // Base / EUR
-      const priceAsset = rates[ticker]; // Asset / EUR
+      const priceQuote = rates[QUOTE_TICKER]; // EUR / QUOTE
+      const priceAsset = rates[ticker]; // EUR / Asset
 
-      return priceBase / priceAsset; // Base / Asset
+      return priceQuote / priceAsset; // Asset / QUOTE
     }
 
     if (type === 'stock') {

--- a/terra/src/Oracle.ts
+++ b/terra/src/Oracle.ts
@@ -3,7 +3,7 @@ import * as http from 'http';
 import * as https from 'https';
 import OracleInfos from './config/OracleInfos';
 
-const UPDATE_INTERVAL = 3600 * 1000; // 1 hour
+const UPDATE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hour
 const QUOTE_TICKER = process.env.FEE_QUOTE_TICKER as string;
 const FIXER_API_KEY = process.env.FIXER_API_KEY as string;
 const POLYGON_API_KEY = process.env.POLYGON_API_KEY as string;

--- a/terra/src/Oracle.ts
+++ b/terra/src/Oracle.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import * as http from 'http';
+import * as https from 'https';
+import OracleInfos from './config/OracleInfos';
+
+const UPDATE_INTERVAL = 3600 * 1000; // 1 hour
+const QUOTE_TICKER = process.env.FEE_QUOTE_TICKER as string;
+const FIXER_API_KEY = process.env.FIXER_API_KEY as string;
+const POLYGON_API_KEY = process.env.POLYGON_API_KEY as string;
+
+const ax = axios.create({
+  httpAgent: new http.Agent({ keepAlive: true }),
+  httpsAgent: new https.Agent({ keepAlive: true }),
+  timeout: 15000,
+});
+
+type OracleType = 'stock' | 'forex' | 'crypto';
+class Oracle {
+  URLs: { [type: string]: string };
+
+  data: {
+    [asset: string]: {
+      type: OracleType;
+      ticker: string;
+      price: number;
+      lastUpdated: number;
+    };
+  };
+
+  constructor() {
+    this.URLs = {
+      crypto:
+        'https://api.coingecko.com/api/v3/coins/TICKER?localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false',
+      forex: `http://data.fixer.io/api/latest?access_key=${FIXER_API_KEY}&symbols=TICKER,${QUOTE_TICKER}`,
+      stock: `https://api.polygon.io/v2/aggs/ticker/TICKER/prev?unadjusted=true&apiKey=${POLYGON_API_KEY}`,
+    };
+
+    this.data = {};
+    for (const [asset, value] of Object.entries(OracleInfos)) {
+      this.data[asset] = {
+        type: value.type,
+        ticker: value.ticker,
+        price: 0,
+        lastUpdated: 0,
+      };
+    }
+  }
+
+  buildURL(type: OracleType, ticker: string): string {
+    return this.URLs[type].replace('TICKER', ticker);
+  }
+
+  // return asset price in QUOTE_TICKER quote
+  async getPrice(asset: string): Promise<number> {
+    if (asset === QUOTE_TICKER) {
+      return 1;
+    }
+
+    const data = this.data[asset];
+    const now = new Date().getTime();
+    if (data.price !== 0 && now < data.lastUpdated + UPDATE_INTERVAL) {
+      return data.price;
+    }
+
+    const URL = this.buildURL(data.type, data.ticker);
+    try {
+      const price = this.parseResposne(asset, (await ax.get(URL)).data);
+      // Update price info
+      this.data[asset].price = price;
+      this.data[asset].lastUpdated = now;
+
+      return price;
+    } catch (err) {
+      console.error(`Failed to load oracle price for ${asset}: ${err}`);
+      return data.price;
+    }
+  }
+
+  parseResposne(asset: string, response: any): number {
+    const type = this.data[asset].type;
+    const ticker = this.data[asset].ticker;
+
+    if (type === 'forex') {
+      const rates = response['rates'];
+      const priceBase = rates[QUOTE_TICKER]; // Base / EUR
+      const priceAsset = rates[ticker]; // Asset / EUR
+
+      return priceBase / priceAsset; // Base / Asset
+    }
+
+    if (type === 'stock') {
+      return parseFloat(response['results'][0]['vw']);
+    }
+
+    if (type === 'crypto') {
+      return response['market_data']['current_price'][
+        QUOTE_TICKER.toLocaleLowerCase()
+      ];
+    }
+
+    return 0;
+  }
+}
+
+export = Oracle;

--- a/terra/src/Oracle.ts
+++ b/terra/src/Oracle.ts
@@ -57,14 +57,14 @@ class Oracle {
     }
 
     const data = this.data[asset];
-    const now = new Date().getTime();
+    const now = Date.now();
     if (data.price !== 0 && now < data.lastUpdated + UPDATE_INTERVAL) {
       return data.price;
     }
 
     const URL = this.buildURL(data.type, data.ticker);
     try {
-      const price = this.parseResposne(asset, (await ax.get(URL)).data);
+      const price = this.parseResponse(asset, (await ax.get(URL)).data);
       // Update price info
       this.data[asset].price = price;
       this.data[asset].lastUpdated = now;
@@ -76,7 +76,7 @@ class Oracle {
     }
   }
 
-  parseResposne(asset: string, response: any): number {
+  parseResponse(asset: string, response: any): number {
     const type = this.data[asset].type;
     const ticker = this.data[asset].ticker;
 

--- a/terra/src/Relayer.ts
+++ b/terra/src/Relayer.ts
@@ -30,8 +30,8 @@ export class Relayer {
     provider.engine.stop();
     web3.setProvider(provider);
 
-    this.fromAddress = provider.getAddress();
     this.web3 = web3;
+    this.fromAddress = provider.getAddress();
   }
 
   loadNonce(): Promise<number> {

--- a/terra/src/config/OracleInfos.ts
+++ b/terra/src/config/OracleInfos.ts
@@ -1,0 +1,88 @@
+const oracleInfos: {
+  [asset: string]: {
+    ticker: string;
+    type:
+      | 'forex' // http://data.fixer.io/api/latest?access_key=${API_KEY}&symbols=KRW,SDR,MNT,USD // base is EUR
+      | 'stock' // https://api.polygon.io/v2/aggs/ticker/AAPL/prev?unadjusted=true&apiKey=${API_KEY}
+      | 'crypto'; // https://api.coingecko.com/api/v3/coins/mirror-protocol?localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false
+  };
+} = {
+  LUNA: {
+    ticker: 'terra-luna',
+    type: 'crypto',
+  },
+  UST: {
+    ticker: 'USD',
+    type: 'forex',
+  },
+  KRT: {
+    ticker: 'KRW',
+    type: 'forex',
+  },
+  SDT: {
+    ticker: 'SDR',
+    type: 'forex',
+  },
+  MNT: {
+    ticker: 'MNT',
+    type: 'forex',
+  },
+  MIR: {
+    ticker: 'mirror-protocol',
+    type: 'crypto',
+  },
+  mAAPL: {
+    ticker: 'AAPL',
+    type: 'stock',
+  },
+  mGOOGL: {
+    ticker: 'GOOGL',
+    type: 'stock',
+  },
+  mTSLA: {
+    ticker: 'TSLA',
+    type: 'stock',
+  },
+  mNFLX: {
+    ticker: 'NFLX',
+    type: 'stock',
+  },
+  mQQQ: {
+    ticker: 'QQQ',
+    type: 'stock',
+  },
+  mTWTR: {
+    ticker: 'TWTR',
+    type: 'stock',
+  },
+  mMSFT: {
+    ticker: 'MSFT',
+    type: 'stock',
+  },
+  mAMZN: {
+    ticker: 'AMZN',
+    type: 'stock',
+  },
+  mBABA: {
+    ticker: 'BABA',
+    type: 'stock',
+  },
+  mIAU: {
+    ticker: 'IAU',
+    type: 'stock',
+  },
+  mSLV: {
+    ticker: 'SLV',
+    type: 'stock',
+  },
+  mUSO: {
+    ticker: 'USO',
+    type: 'stock',
+  },
+  mVIXY: {
+    ticker: 'VIXY',
+    type: 'stock',
+  },
+};
+
+export = oracleInfos;

--- a/terra/src/config/OracleInfos.ts
+++ b/terra/src/config/OracleInfos.ts
@@ -20,7 +20,7 @@ const oracleInfos: {
     type: 'forex',
   },
   SDT: {
-    ticker: 'SDR',
+    ticker: 'XDR',
     type: 'forex',
   },
   MNT: {

--- a/terra/src/index.ts
+++ b/terra/src/index.ts
@@ -6,17 +6,16 @@ const shuttle = new Shuttle();
 
 console.info(`
 Start ShuttleTerra
-\n
+
 TERRA_CHAIN_ID: ${process.env.TERRA_CHAIN_ID}
 ETH_CHAIN_ID: ${process.env.ETH_CHAIN_ID}
-\n
+
 TERRA_TRACKING_ADDR: ${process.env.TERRA_TRACKING_ADDR}
-\n
+
 FEE_RATE: ${process.env.FEE_RATE}
 FEE_MIN_AMOUNT: ${process.env.FEE_MIN_AMOUNT}
 FEE_QUOTE_TICKER: ${process.env.FEE_QUOTE_TICKER}
 -----------------------------------------------------------
-\n\n
 `);
 
 shuttle.startMonitoring().catch((err) => {

--- a/terra/src/index.ts
+++ b/terra/src/index.ts
@@ -4,6 +4,20 @@ import Shuttle from './Shuttle';
 
 const shuttle = new Shuttle();
 
+console.info(`
+Start ShuttleTerra
+
+TERRA_CHAIN_ID: ${process.env.TERRA_CHAIN_ID}
+ETH_CHAIN_ID: ${process.env.ETH_CHAIN_ID}
+
+TERRA_TRACKING_ADDR: ${process.env.TERRA_TRACKING_ADDR}
+
+FEE_RATE: ${process.env.FEE_RATE}
+FEE_MIN_AMOUNT: ${process.env.FEE_MIN_AMOUNT}
+FEE_QUOTE_TICKER: ${process.env.FEE_QUOTE_TICKER}
+--- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+`);
+
 shuttle.startMonitoring().catch((err) => {
   console.error(`Exit with ${err}`);
 });

--- a/terra/src/index.ts
+++ b/terra/src/index.ts
@@ -6,16 +6,17 @@ const shuttle = new Shuttle();
 
 console.info(`
 Start ShuttleTerra
-
+\n
 TERRA_CHAIN_ID: ${process.env.TERRA_CHAIN_ID}
 ETH_CHAIN_ID: ${process.env.ETH_CHAIN_ID}
-
+\n
 TERRA_TRACKING_ADDR: ${process.env.TERRA_TRACKING_ADDR}
-
+\n
 FEE_RATE: ${process.env.FEE_RATE}
 FEE_MIN_AMOUNT: ${process.env.FEE_MIN_AMOUNT}
 FEE_QUOTE_TICKER: ${process.env.FEE_QUOTE_TICKER}
---- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+-----------------------------------------------------------
+\n\n
 `);
 
 shuttle.startMonitoring().catch((err) => {


### PR DESCRIPTION
## Summary 
Ethereum transaction fee is 100x bigger than Terra transaction fee, so a attacker can easily drain Shuttle fee pool(ETH) with small amount of Terra side asset by spamming transactions to Shuttle. 

To prevent this case, we will charge shuttle fee in following equation.
```
max($1, 0.1% * amount)
```

We use various oracle sources to compute $1 value of asset. If a user sends smaller amount asset than $1 value, that tx will not be relayed to Ethereum side.